### PR TITLE
Fix stray line in OpenAI provider

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
@@ -313,7 +313,6 @@ object OpenAIProvider : Provider<ProviderSetting.OpenAI> {
     }
 
     private fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
-        111
         messages
             .filter {
                 it.isValidToUpload()


### PR DESCRIPTION
## Summary
- remove stray debug integer from `OpenAIProvider`

## Testing
- `./gradlew -q tasks --all` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c304126288323a58f57747140ca5f